### PR TITLE
feat: add JSON/HTTP commit log

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"log"
+
+	"github.com/rajatgupta24/diservices/internal/server"
+)
+
+func main() {
+	srv := server.NewHTTPServer(":8080")
+	log.Fatal(srv.ListenAndServe())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/rajatgupta24/diservices
+
+go 1.20
+
+require github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func NewHTTPServer(addr string) *http.Server {
+	httpsrv := newHTTPServer()
+	r := mux.NewRouter()
+
+	r.HandleFunc("/", httpsrv.handleProduce).Methods("POST")
+	r.HandleFunc("/", httpsrv.handleConsume).Methods("GET")
+
+	return &http.Server{
+		Addr:    addr,
+		Handler: r,
+	}
+}
+
+type httpServer struct {
+	Log *Log
+}
+
+func newHTTPServer() *httpServer {
+	return &httpServer{
+		Log: NewLog(),
+	}
+}
+
+type ProduceRequest struct {
+	Record Record `json:"record"`
+}
+
+type ProduceResponse struct {
+	Offset uint64 `json:"offset"`
+}
+
+type ConsumeRequest struct {
+	Offset uint64 `json:"offset"`
+}
+
+type ConsumeResponse struct {
+	Record Record `json:"record"`
+}
+
+func (s *httpServer) handleProduce(w http.ResponseWriter, r *http.Request) {
+	var req ProduceRequest
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	off, err := s.Log.Append(req.Record)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	res := ProduceResponse{Offset: off}
+	err = json.NewEncoder(w).Encode(res)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *httpServer) handleConsume(w http.ResponseWriter, r *http.Request) {
+	var req ConsumeRequest
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	record, err := s.Log.Read(req.Offset)
+	if err == ErrOffsetNotFound {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	res := ConsumeResponse{Record: record}
+	err = json.NewEncoder(w).Encode(res)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Log struct {
+	mu      sync.Mutex
+	records []Record
+}
+
+func NewLog() *Log {
+	return &Log{}
+}
+
+func (c *Log) Append(record Record) (uint64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	record.Offset = uint64(len(c.records))
+	c.records = append(c.records, record)
+	return record.Offset, nil
+}
+
+func (c *Log) Read(offset uint64) (Record, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if offset >= uint64(len(c.records)) {
+		return Record{}, ErrOffsetNotFound
+	}
+	return c.records[offset], nil
+}
+
+type Record struct {
+	Value  []byte `json:"value"`
+	Offset uint64 `json:"offset"`
+}
+
+var ErrOffsetNotFound = fmt.Errorf("offset not found")


### PR DESCRIPTION
built a simple JSON/HTTP commit log service that accepts and responds with JSON and stores the records in those requests to an in-memory log.